### PR TITLE
Restore array reference equality check

### DIFF
--- a/src/Data/Eq.js
+++ b/src/Data/Eq.js
@@ -13,6 +13,7 @@ export const eqStringImpl = refEq;
 export const eqArrayImpl = function (f) {
   return function (xs) {
     return function (ys) {
+      if (xs === ys) return true;
       if (xs.length !== ys.length) return false;
       for (var i = 0; i < xs.length; i++) {
         if (!f(xs[i])(ys[i])) return false;


### PR DESCRIPTION
  - This reverts the change in https://github.com/purescript/purescript-prelude/pull/187
  - Provides a major optimization for array equality checking.
  - Opting into this functionality within all nested records at the moment seems unrealistic compared to just restoring this here.

Reviewed By:

